### PR TITLE
Allow filtering on Array fields.

### DIFF
--- a/src/components/feature_modal.js
+++ b/src/components/feature_modal.js
@@ -87,7 +87,7 @@ const FeatureModal = ({color, media, data, title, subtitle, onCloseClick}) => (
 
 module.exports = connect(
   (state, ownProps) => {
-    const features = getFlattenedFeatures(state)
+    const features = getFlattenedFeatures(state, {safe: true})
     const colorIndex = getColorIndex(state)
     const fieldMapping = getFieldMapping(state)
     const visibleFields = getVisibleFields(state)

--- a/src/constants.js
+++ b/src/constants.js
@@ -8,7 +8,10 @@ const FIELD_TYPES = {
   IMAGE: 'image',
   VIDEO: 'video',
   MEDIA: 'media',
-  LINK: 'link'
+  LINK: 'link',
+  ARRAY: 'array',
+  STRING_OR_ARRAY: 'string_or_array',
+  NUMBER_OR_ARRAY: 'number_or_array'
 }
 
 const FILTER_TYPES = {

--- a/src/selectors/flattened_features.js
+++ b/src/selectors/flattened_features.js
@@ -13,8 +13,9 @@ const getFlattenedFeatures = createSelector(
   (state) => state.features,
   getFieldAnalysis,
   getIdFieldNames,
-  (features, fieldAnalysis, idFieldNames) => features.map(f => {
-    const properties = flat(f.properties)
+  (state, opts) => opts,
+  (features, fieldAnalysis, idFieldNames, opts) => features.map(f => {
+    const properties = flat(f.properties, opts)
     // We use an existing id feature property, if it is unique across all features,
     // or we use any unique id field we find under properties, or, failing that,
     // we generate a unique id.

--- a/src/selectors/map_geojson.js
+++ b/src/selectors/map_geojson.js
@@ -13,7 +13,7 @@ const getMapGeoJSON = createSelector(
         const props = feature.properties
         const newProps = Object.assign({}, props, {
           __mf_id: feature.id,
-          __mf_color: colorIndex[props[coloredField]].slice(1)
+          __mf_color: colorIndex[props[coloredField] || props[coloredField + '.0']].slice(1)
         })
         // Coerce dates to numbers
         // TODO: This should be faster by using field analysis to find date

--- a/src/util/intl_helpers.js
+++ b/src/util/intl_helpers.js
@@ -1,7 +1,7 @@
 const toCase = require('case')
 const roundTo = require('round-to')
 
-const createMessage = section => value => {
+const createMessage = section => function formatMsg (value) {
   let msg
   let id
   if (typeof value === 'string') {
@@ -12,7 +12,10 @@ const createMessage = section => value => {
     }
     id = value.replace(' ', '_').toLowerCase()
   } else if (Array.isArray(value)) {
-    msg = value.map(v => roundTo(v, 5)).join(' ')
+    msg = value.map(v => {
+      if (typeof v === 'number') return roundTo(v, 5)
+      return formatMsg(v).defaultMessage
+    }).join(', ')
     id = value.join('_')
   } else {
     msg = value.toString()

--- a/statics/sample.geojson
+++ b/statics/sample.geojson
@@ -4,7 +4,7 @@
     {
       "properties": {
         "people": "burch_andrews",
-        "happening": "fishing",
+        "happening": ["fishing", "bobcats"],
         "impacts": "Violation of sensitive site",
         "placename": "Sims Thermal",
         "today": "2014-03-11",


### PR DESCRIPTION
This is a little tricky because Mapbox filters do not work on arrays. Instead we flatten the array into:
```
arrayField.0: arrayValue0, arrayField.1: arrayValue1, arrayField.2: arrayValue2
```
Then pass the same filter to each of these and group with an ‘any’ filter.

Things not working quite right, or untested:

- Arrays that contain non-string fields
- The Popup component does not render the title or subtitle correctly if these are array fields. Currently the Popup gets its props from the Mapbox component, which has the flattened data, and the Popup is rendered in a separate context without access to the redux store, so we can't access the selectors.
- Some of the code for array values is a little fragile and edge-cases might break things.
- ODK Collect tends to return space-separated fields rather than array fields, so we need to detect and transform those.
