### PR TITLE
Selector craziness

### DIFF
--- a/config.json
+++ b/config.json
@@ -26,5 +26,6 @@
   ],
   "defaultColor": "#555555",
   "dateFormatShort": "ll",
-  "dateFormatLong": "LL"
+  "dateFormatLong": "LL",
+  "labelChars": "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
 }

--- a/example/index.js
+++ b/example/index.js
@@ -4,20 +4,7 @@ const MapFilter = require('../')
 const fs = require('fs')
 const path = require('path')
 
-// TODO: parsing dates should be in a selector
-/**
- * Attempt to parse a datestring, returning `false` if it can't be parsed
- * @param {string} possibleDate [description]
- * @return {date|boolean} returns a Date object or `false` if not a date.
- */
-function reviveDate (k, v) {
-  if (typeof v !== 'string') return v
-  var date = new Date(v)
-  if (isNaN(date)) return v
-  return date
-}
-
 const sampleGeoJSON = fs.readFileSync(path.join(__dirname, './sample.geojson'), 'utf8')
-const features = JSON.parse(sampleGeoJSON, reviveDate).features
+const features = JSON.parse(sampleGeoJSON).features
 
 ReactDOM.render(<MapFilter features={features} />, document.getElementById('root'))

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "flat": "^2.0.1",
     "geojsonhint": "^1.2.0",
     "get-scrollbar-width": "^1.0.4",
+    "is-plain-object": "^2.0.1",
     "lodash": "^4.16.4",
     "mapbox-gl": "^0.27.0",
     "material-ui": "^0.16.4",

--- a/src/components/feature_modal.js
+++ b/src/components/feature_modal.js
@@ -1,13 +1,12 @@
 const React = require('react')
 
 const { connect } = require('react-redux')
-const find = require('lodash/find')
 const { Card, CardMedia, CardText, CardHeader } = require('material-ui/Card')
 const IconButton = require('material-ui/IconButton').default
 const CloseIcon = require('material-ui/svg-icons/navigation/close').default
 const {FormattedMessage} = require('react-intl')
 
-const getFlattenedFeatures = require('../selectors/flattened_features')
+const getFeaturesById = require('../selectors/features_by_id')
 const getFieldMapping = require('../selectors/field_mapping')
 const getColorIndex = require('../selectors/color_index')
 const getVisibleFields = require('../selectors/visible_fields')
@@ -87,14 +86,14 @@ const FeatureModal = ({color, media, data, title, subtitle, onCloseClick}) => (
 
 module.exports = connect(
   (state, ownProps) => {
-    const features = getFlattenedFeatures(state, {safe: true})
+    const featuresById = getFeaturesById(state)
     const colorIndex = getColorIndex(state)
     const fieldMapping = getFieldMapping(state)
     const visibleFields = getVisibleFields(state)
     const fieldAnalysis = getFieldAnalysis(state)
 
-    const feature = find(features, {id: ownProps.id})
-    if (!feature) return
+    const feature = featuresById[ownProps.id]
+    if (!feature) return {}
     const geojsonProps = feature.properties
     const data = visibleFields
       .filter(f => typeof geojsonProps[f] !== 'undefined')

--- a/src/components/map_view.js
+++ b/src/components/map_view.js
@@ -47,7 +47,7 @@ const pointHoverStyleLayer = {
   id: 'features-hover',
   type: 'symbol',
   source: 'features',
-  filter: ['==', '$id', ''],
+  filter: ['==', '__mf_id', ''],
   layout: {
     'icon-image': 'marker-{__mf_color}-hover',
     'icon-allow-overlap': true,
@@ -119,12 +119,12 @@ class MapView extends React.Component {
     this.map.getCanvas().style.cursor = (features.length) ? 'pointer' : ''
     if (!features.length) {
       this.popup.remove()
-      this.map.setFilter('features-hover', ['==', '$id', ''])
+      this.map.setFilter('features-hover', ['==', '__mf_id', ''])
       return
     }
     const props = features[0].properties
     const hoveredFeatureId = props.__mf_id
-    this.map.setFilter('features-hover', ['==', '$id', hoveredFeatureId])
+    this.map.setFilter('features-hover', ['==', '__mf_id', hoveredFeatureId])
     // Popuplate the popup and set its coordinates
     // based on the feature found.
     if (!this.popup._map || hoveredFeatureId && hoveredFeatureId !== this.popup.__featureId) {

--- a/src/components/map_view.js
+++ b/src/components/map_view.js
@@ -47,7 +47,7 @@ const pointHoverStyleLayer = {
   id: 'features-hover',
   type: 'symbol',
   source: 'features',
-  filter: ['==', 'id', ''],
+  filter: ['==', '$id', ''],
   layout: {
     'icon-image': 'marker-{__mf_color}-hover',
     'icon-allow-overlap': true,
@@ -107,7 +107,7 @@ class MapView extends React.Component {
       {layers: ['features', 'features-hover']}
     )
     if (!features.length) return
-    this.props.onMarkerClick(features[0].properties.id)
+    this.props.onMarkerClick(features[0].properties.__mf_id)
   }
 
   handleMouseMove = (e) => {
@@ -119,12 +119,12 @@ class MapView extends React.Component {
     this.map.getCanvas().style.cursor = (features.length) ? 'pointer' : ''
     if (!features.length) {
       this.popup.remove()
-      this.map.setFilter('features-hover', ['==', 'id', ''])
+      this.map.setFilter('features-hover', ['==', '$id', ''])
       return
     }
-    var props = features[0].properties
-    var hoveredFeatureId = props.id
-    this.map.setFilter('features-hover', ['==', 'id', hoveredFeatureId])
+    const props = features[0].properties
+    const hoveredFeatureId = props.__mf_id
+    this.map.setFilter('features-hover', ['==', '$id', hoveredFeatureId])
     // Popuplate the popup and set its coordinates
     // based on the feature found.
     if (!this.popup._map || hoveredFeatureId && hoveredFeatureId !== this.popup.__featureId) {

--- a/src/reducers/filters.js
+++ b/src/reducers/filters.js
@@ -1,5 +1,23 @@
 const omit = require('lodash/omit')
 
+/**
+ * Filter state is an object with whose properties are field names
+ * that have filters set, and values are objects whose properties
+ * are expressions, values arrays of expression arguments, e.g.
+ * state.filter = {
+ *   happening: {
+ *     in: ['mining', 'fishing']
+ *   },
+ *   today: {
+ *     '>=': 1415692800000,
+ *     '<=': 1418198400000
+ *   }
+ * }
+ * The only operator logic for combining filters that we support currently
+ * is "all". These simplified filters are converted to the syntax used by
+ * Mapbox https://www.mapbox.com/mapbox-gl-style-spec/#types-filter in
+ * the selector selectors/mapbox_filter.js
+ */
 const filters = (state = {}, {type, payload = {}}) => {
   const {key, exp, val} = payload
   switch (type) {

--- a/src/selectors/features_by_id.js
+++ b/src/selectors/features_by_id.js
@@ -1,0 +1,13 @@
+const { createSelector } = require('reselect')
+
+const getFlattenedFeatures = require('./flattened_features')
+
+const getFeaturesById = createSelector(
+  getFlattenedFeatures,
+  (features) => features.reduce((p, v) => {
+    p[v.id] = v
+    return p
+  }, {})
+)
+
+module.exports = getFeaturesById

--- a/src/selectors/features_with_ids.js
+++ b/src/selectors/features_with_ids.js
@@ -1,0 +1,25 @@
+const { createSelector } = require('reselect')
+const randomBytes = require('randombytes')
+
+const getFieldAnalysis = require('./field_analysis')
+const getIdFieldNames = require('./id_fields')
+
+function uniqueId () {
+  return randomBytes(8).toString('hex')
+}
+
+const getFeaturesWithIds = createSelector(
+  (state) => state.features,
+  getFieldAnalysis,
+  getIdFieldNames,
+  (features, fieldAnalysis, idFieldNames) => features.map(f => {
+    // We use an existing id feature property, if it is unique across all features,
+    // or we use any unique id field we find under properties, or, failing that,
+    // we generate a unique id.
+    const id = fieldAnalysis.__validGeoJsonIdField ? f.id
+      : f.properties[idFieldNames[0]] || uniqueId()
+    return Object.assign({}, f, {id})
+  })
+)
+
+module.exports = getFeaturesWithIds

--- a/src/selectors/field_analysis.js
+++ b/src/selectors/field_analysis.js
@@ -217,9 +217,10 @@ const getFieldAnalysis = createSelector(
         }
         if (thisType === FIELD_TYPES.ARRAY) {
           field.maxArrayLength = Math.max(field.maxArrayLength || 1, value.length)
-        }
-        if (thisType === FIELD_TYPES.NUMBER || thisType === FIELD_TYPES.DATE) {
+        } else if (thisType === FIELD_TYPES.NUMBER) {
           field.valueStats = statReduce(field.valueStats, value, i)
+        } else if (thisType === FIELD_TYPES.DATE) {
+          field.valueStats = statReduce(field.valueStats, new Date(value), i)
         }
         field.values = valuesReduce(field.values, value)
       }

--- a/src/selectors/field_analysis.js
+++ b/src/selectors/field_analysis.js
@@ -162,6 +162,16 @@ function isDate (v) {
   return new Date(v) !== 'Invalid Date' && !isNaN(new Date(v))
 }
 
+/**
+ * Guess if a field is a UUID: if it has a length greater than
+ * 30, no variance in length, and is only one word.
+**/
+function isUUIDField (f) {
+  if (!f.isUnique) return
+  if (f.type !== FIELD_TYPES.STRING) return
+  return f.lengthStats.mean > 30 &&
+    f.lengthStats.vari === 0 &&
+    f.wordStats.max === 1
 }
 
 /**
@@ -218,6 +228,7 @@ const getFieldAnalysis = createSelector(
     for (let fieldname in analysis) {
       let field = analysis[fieldname]
       field.isUnique = isUnique(field, features)
+      if (isUUIDField(field)) field.type = FIELD_TYPES.UUID
       field.filterType = getFilterType(field)
     }
     const isIdFieldUnique = Object.keys(idFieldValues).length === features.length

--- a/src/selectors/filterable_features.js
+++ b/src/selectors/filterable_features.js
@@ -1,0 +1,31 @@
+const flat = require('flat')
+const { createSelector } = require('reselect')
+
+const getFeaturesWithIds = require('./features_with_ids')
+const getFieldAnalysis = require('./field_analysis')
+const getIdFieldNames = require('./id_fields')
+const {FIELD_TYPES} = require('../constants')
+
+function dateStringToNumber (dateString) {
+  if (typeof dateString !== 'string') return dateString
+  return +(new Date(dateString))
+}
+
+const getFilterableFeatures = createSelector(
+  getFeaturesWithIds,
+  getFieldAnalysis,
+  getIdFieldNames,
+  (features, fieldAnalysis, idFieldNames) => features.map(f => {
+    // We can't filter nested objects or arrays, so we flatten feature properties
+    const properties = flat(f.properties)
+    // To filter dates we need to convert date strings to numbers
+    Object.keys(fieldAnalysis)
+      .filter(f => fieldAnalysis[f].type === FIELD_TYPES.DATE)
+      .forEach(f => {
+        properties[f] = dateStringToNumber(properties[f])
+      })
+    return Object.assign({}, f, {properties})
+  })
+)
+
+module.exports = getFilterableFeatures

--- a/src/selectors/filterable_features.js
+++ b/src/selectors/filterable_features.js
@@ -7,7 +7,6 @@ const getIdFieldNames = require('./id_fields')
 const {FIELD_TYPES} = require('../constants')
 
 function dateStringToNumber (dateString) {
-  if (typeof dateString !== 'string') return dateString
   return +(new Date(dateString))
 }
 

--- a/src/selectors/filtered_features.js
+++ b/src/selectors/filtered_features.js
@@ -1,32 +1,24 @@
-var ff = require('feature-filter-geojson')
 const { createSelector } = require('reselect')
+const assign = require('object-assign')
 
-const getFlattenedFeatures = require('./flattened_features')
-const getMapboxFilter = require('./mapbox_filter')
-
-const datesToNumbers = createSelector(
-  getFlattenedFeatures,
-  features => features.map(feature => {
-    const props = feature.properties
-    const newProps = Object.assign({}, props)
-    // Coerce dates to numbers
-    // TODO: This should be faster by using field analysis to find date
-    // fields rather than iterating properties on each feature
-    for (let key in props) {
-      if (props[key] instanceof Date) {
-        newProps[key] = +props[key]
-      }
-    }
-    return Object.assign({}, feature, {
-      properties: newProps
-    })
-  })
-)
+const getFeaturesById = require('./features_by_id')
+const getRawFilteredFeatures = require('./filtered_features_raw')
+const getColorIndex = require('./color_index')
+const getColoredField = require('./colored_field')
+const CONFIG = require('../../config.json')
 
 const getFilteredFeatures = createSelector(
-  datesToNumbers,
-  getMapboxFilter,
-  (features, filter) => features.filter(ff(filter))
+  getFeaturesById,
+  getRawFilteredFeatures,
+  getColoredField,
+  getColorIndex,
+  (featuresById, filteredFeatures, colorIndex, coloredField) => {
+    return filteredFeatures.map((f, i) => {
+      return assign({}, f, {
+        __label: CONFIG.labelChars.charAt(i)
+      })
+    })
+  }
 )
 
 module.exports = getFilteredFeatures

--- a/src/selectors/filtered_features.js
+++ b/src/selectors/filtered_features.js
@@ -14,7 +14,7 @@ const getFilteredFeatures = createSelector(
   getColorIndex,
   (featuresById, filteredFeatures, colorIndex, coloredField) => {
     return filteredFeatures.map((f, i) => {
-      return assign({}, f, {
+      return assign({}, featuresById[f.id], {
         __label: CONFIG.labelChars.charAt(i)
       })
     })

--- a/src/selectors/filtered_features_raw.js
+++ b/src/selectors/filtered_features_raw.js
@@ -1,0 +1,13 @@
+var ff = require('feature-filter-geojson')
+const { createSelector } = require('reselect')
+
+const getFilterableFeatures = require('./filterable_features')
+const getMapboxFilter = require('./mapbox_filter')
+
+const getRawFilteredFeatures = createSelector(
+  getFilterableFeatures,
+  getMapboxFilter,
+  (features, filter) => features.filter(ff(filter))
+)
+
+module.exports = getRawFilteredFeatures

--- a/src/selectors/images.js
+++ b/src/selectors/images.js
@@ -1,7 +1,7 @@
 const { createSelector } = require('reselect')
 
 const getFieldAnalysis = require('./field_analysis')
-const getFilteredFeatures = require('./filtered_features')
+const getRawFilteredFeatures = require('./filtered_features_raw')
 const {FIELD_TYPES} = require('../constants')
 
 const getImageFieldNames = createSelector(
@@ -11,11 +11,8 @@ const getImageFieldNames = createSelector(
   )
 )
 
-/**
- * Pick the date field that appears in most records
- */
 const getImages = createSelector(
-  getFilteredFeatures,
+  getRawFilteredFeatures,
   getImageFieldNames,
   (features, imageFieldNames) => {
     return features.reduce((p, feature) => {

--- a/src/util/prop_types.js
+++ b/src/util/prop_types.js
@@ -6,6 +6,10 @@ const {PropTypes} = require('react')
 // We need to ensure each feature has an id so we can handle
 // callbacks for when a marker is clicked or hovered.
 const mapViewFeature = PropTypes.shape({
+  id: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number
+  ]).isRequired,
   type: PropTypes.oneOf(['Feature']),
   geometry: PropTypes.oneOfType([
     PropTypes.oneOf([null]),
@@ -15,11 +19,11 @@ const mapViewFeature = PropTypes.shape({
     })
   ]).isRequired,
   properties: PropTypes.shape({
+    __mf_color: PropTypes.string.isRequired,
     __mf_id: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.number
-    ]).isRequired,
-    __mf_color: PropTypes.string.isRequired
+    ]).isRequired
   }).isRequired
 })
 


### PR DESCRIPTION
This re-organizes the selectors, and does some crazy stuff, but there is a twisted logic behind it... These are some of the factors behind the craziness:

- In mapbox-gl-js changing the geojson is costly, and filtering is fast, so it's better to pass unfiltered geojson and the filter to the map view.
- In order to filter data, it needs to be completely flattened, including arrays
- For displaying data (e.g. in Feature Details view), we don't want arrays flattened
- mapbox-gl-js does not currently return feature.id for hovered features, so we need to set an id on feature.properties, and guarantee that it is unique.
- in order to color markers according to a field, we must add a color prop to feature.properties.
- we don't want memory to get out of control, so we try to re-use larger objects (e.g. feature.properties) as much as possible.

@mojodna with this the selectors you need are:

- `map_geojson.js` for the geojson to pass to the mapview
- `mapbox_filter.js` for the filter in Mapbox format to pass to mapview
- `filtered_features.js` for the feature pages in the report view - each feature will have a `feature.__color` and `feature.__label` - note that these are not under `feature.properties`, this is to avoid creating yet another clone of `feature.properties` which could take more memory on larger featureCollections with lots of properties.
- For the state of the filter config dialog you need `visible_filters.js` for which filters are currently shown (note, this is slightly different from `state.visibleFilters` because that starts off empty) and `filterable_fields.js`.

I need to finish up the documentation on selectors, will look at it tomorrow with a clearer head. I needed to make quite a lot of selectors to avoid circular references, and because we need the data in lots of different ways for the different views.
