### PR TITLE
[Work in progress] Table view

### DIFF
--- a/src/components/table/index.js
+++ b/src/components/table/index.js
@@ -1,0 +1,10 @@
+import React from 'react'
+
+class TableView extends React.Component {
+
+  render () {
+    return <div />
+  }
+}
+
+export default TableView

--- a/src/components/table/index.js
+++ b/src/components/table/index.js
@@ -1,9 +1,37 @@
 import React from 'react'
+import Table from 'react-virtualized/dist/commonjs/Table/Table'
+import Column from 'react-virtualized/dist/commonjs/Table/Column'
+import AutoSizer from 'react-virtualized/dist/commonjs/AutoSizer'
+
+const rowHeight = 30
 
 class TableView extends React.Component {
-
   render () {
-    return <div />
+    console.log(this.props)
+    const { features } = this.props
+    const rowGetter = ({ index }) => features[index].properties
+    return (
+      <div style={{width: '100%', height: '100%', position: 'absolute'}}>
+        <AutoSizer>
+          {({ width, height }) => (
+            <Table
+              ref='table'
+              headerHeight={rowHeight}
+              height={height}
+              rowCount={features.length}
+              rowGetter={rowGetter}
+              rowHeight={rowHeight}
+              width={width}
+            >
+              <Column
+                dataKey='area'
+                width={90}
+              />
+            </Table>
+          )}
+        </AutoSizer>
+      </div>
+    )
   }
 }
 

--- a/src/components/table/index.js
+++ b/src/components/table/index.js
@@ -3,30 +3,49 @@ import Table from 'react-virtualized/dist/commonjs/Table/Table'
 import Column from 'react-virtualized/dist/commonjs/Table/Column'
 import AutoSizer from 'react-virtualized/dist/commonjs/AutoSizer'
 
+require('react-virtualized/styles.css')
+
 const rowHeight = 30
 
 class TableView extends React.Component {
+  shouldComponentUpdate (nextProps) {
+    return nextProps.filteredFeatures !== this.props.filteredFeatures
+  }
+
+  getColumns () {
+    const { filteredFeatures } = this.props
+    const featureWithProperties = filteredFeatures.find(d => d.hasOwnProperty('properties'))
+    if (!featureWithProperties) { return false }
+    return Object.keys(featureWithProperties.properties)
+  }
+
   render () {
-    console.log(this.props)
-    const { features } = this.props
-    const rowGetter = ({ index }) => features[index].properties
+    const { filteredFeatures } = this.props
+    const rowGetter = ({ index }) => filteredFeatures[index].properties
+    const columns = this.getColumns()
     return (
       <div style={{width: '100%', height: '100%', position: 'absolute'}}>
         <AutoSizer>
           {({ width, height }) => (
             <Table
+              disableHeader={false}
               ref='table'
               headerHeight={rowHeight}
               height={height}
-              rowCount={features.length}
+              rowCount={filteredFeatures.length}
               rowGetter={rowGetter}
               rowHeight={rowHeight}
               width={width}
             >
-              <Column
-                dataKey='area'
-                width={90}
-              />
+              {columns.map(column => (
+                <Column
+                  label={column}
+                  key={column}
+                  dataKey={column}
+                  width={1}
+                  flexGrow={1}
+                />
+              ))}
             </Table>
           )}
         </AutoSizer>

--- a/src/components/table/index.js
+++ b/src/components/table/index.js
@@ -2,6 +2,7 @@ import React from 'react'
 import Table from 'react-virtualized/dist/commonjs/Table/Table'
 import Column from 'react-virtualized/dist/commonjs/Table/Column'
 import AutoSizer from 'react-virtualized/dist/commonjs/AutoSizer'
+import getScrollBarWidth from 'get-scrollbar-width'
 
 require('react-virtualized/styles.css')
 
@@ -12,22 +13,31 @@ class TableView extends React.Component {
     return nextProps.filteredFeatures !== this.props.filteredFeatures
   }
 
+  componentWillMount () {
+    this.scrollbarWidth = getScrollBarWidth()
+  }
+
   getColumns () {
     const { filteredFeatures } = this.props
     const featureWithProperties = filteredFeatures.find(d => d.hasOwnProperty('properties'))
-    if (!featureWithProperties) { return false }
+    if (!featureWithProperties) { return [] }
     return Object.keys(featureWithProperties.properties)
   }
 
   render () {
     const { filteredFeatures } = this.props
     const rowGetter = ({ index }) => filteredFeatures[index].properties
+    const rowLength = filteredFeatures.length
     const columns = this.getColumns()
     return (
       <div style={{width: '100%', height: '100%', position: 'absolute'}}>
         <AutoSizer>
-          {({ width, height }) => (
-            <Table
+          {({ width, height }) => {
+            const totalHeight = rowHeight * rowLength
+            const overflow = totalHeight > height
+            const columnWidth = overflow ? (width - this.scrollbarWidth) / columns.length
+              : width / columns.length
+            return <Table
               disableHeader={false}
               ref='table'
               headerHeight={rowHeight}
@@ -42,12 +52,11 @@ class TableView extends React.Component {
                   label={column}
                   key={column}
                   dataKey={column}
-                  width={1}
-                  flexGrow={1}
+                  width={columnWidth}
                 />
               ))}
             </Table>
-          )}
+          }}
         </AutoSizer>
       </div>
     )

--- a/src/containers/index_route.js
+++ b/src/containers/index_route.js
@@ -14,6 +14,7 @@ import Settings from '../components/settings'
 import MapView from '../components/map'
 import ReportView from '../components/report'
 import MediaView from '../components/media'
+import TableView from '../components/table'
 
 const styles = {
   outer: {
@@ -90,6 +91,9 @@ IndexRoute.defaultProps = {
   }, {
     id: 'report',
     component: ReportView
+  }, {
+    id: 'table',
+    component: TableView
   }]
 }
 

--- a/src/containers/top_bar.js
+++ b/src/containers/top_bar.js
@@ -63,6 +63,11 @@ const messages = defineMessages({
     id: 'topbar.report',
     defaultMessage: 'Report',
     description: 'Report tab name'
+  },
+  table: {
+    id: 'topbar.table',
+    defaultMessage: 'Table',
+    description: 'Table tab name'
   }
 })
 


### PR DESCRIPTION
Syncing my work for the day. I'll pick this up tomorrow. Things left to do:

- [ ] Sorting
- [ ] Having a way to specify which data columns to pull out from the geojson properties object.

Anything else?

@mojodna on that last point, this is just naively taking the first geojson feature from `filteredFeatures` that has a `properties` property, and using the keys from that property to determine the table headers. I think it makes sense to pass some sort of configuration, at the very least determining which properties to pick. Otherwise for anything more complicated the table becomes useless.

If we want to avoid passing configuration, an alternative would some UI that lets you control which columns to show. Open to other suggestions as well.

<img width="1419" alt="screen shot 2017-06-01 at 7 52 28 pm" src="https://cloud.githubusercontent.com/assets/1590802/26695905/81a3b168-4704-11e7-88e9-92b0a6c33163.png">
