### PR TITLE
Controllable filters

### DIFF
--- a/src/containers/MapFilter.js
+++ b/src/containers/MapFilter.js
@@ -19,6 +19,7 @@ import {capitalize} from '../util/text_helpers'
 import reducers from '../reducers'
 import controlledStore from '../controlled_store'
 import config from '../../config.json'
+import stateReconciler from '../util/stateReconciler'
 
 import esStrings from '../../locales/es.json'
 import frStrings from '../../locales/fr.json'
@@ -53,9 +54,10 @@ if (process.env.NODE_ENV !== 'production' && window.__REDUX_DEVTOOLS_EXTENSION_C
   composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
 }
 
+
 const storeEnhancer = composeEnhancers(
   applyMiddleware(thunk),
-  autoRehydrate()
+  autoRehydrate({stateReconciler})
 )
 
 const reduxPersistOptions = {

--- a/src/containers/MapFilter.js
+++ b/src/containers/MapFilter.js
@@ -71,6 +71,8 @@ const reduxPersistOptions = {
 }
 
 const controllableProps = [
+  'filters',
+  'filterFields',
   'features',
   'mapPosition',
   'mapStyle',
@@ -95,6 +97,26 @@ class MapFilter extends React.Component {
      * default: `default`
      */
     datasetName: PropTypes.string,
+    /**
+     * An object of filters
+     * Default: `{}`
+     */
+    filters: PropTypes.object,
+    /**
+     * Called whenever filters are changed
+     * with a new array of filter objects.
+    */
+    onChangeFilters: PropTypes.func,
+    /**
+     * Called whenever filters are changed
+     * with a new array of filter objects.
+    */
+    onChangeFilterFields: PropTypes.func,
+    /**
+     * An array of filter fields
+     * Default: `[]`
+     */
+    filterFields: PropTypes.array,
     /**
      * An array of GeoJSON Feature objects
      * Default: `[]`

--- a/src/util/stateReconciler.js
+++ b/src/util/stateReconciler.js
@@ -1,0 +1,42 @@
+import isPlainObject from 'lodash/isPlainObject'
+import merge from 'lodash/merge'
+
+module.exports = function (state, inboundState, reducedState, log) {
+  let newState = Object.assign({}, reducedState)
+    Object.keys(inboundState).forEach((key) => {
+      // if initialState does not have key, skip auto rehydration
+      if (!state.hasOwnProperty(key)) return
+
+      // if initial state is an object but inbound state is null/undefined, skip
+      if (typeof state[key] === 'object' && !inboundState[key]) {
+        if (log) console.log('redux-persist/autoRehydrate: sub state for key `%s` is falsy but initial state is an object, skipping autoRehydrate.', key)
+      return
+      }
+
+    // if reducer modifies substate, skip auto rehydration
+    if (state[key] !== reducedState[key]) {
+      if (log) console.log('redux-persist/autoRehydrate: sub state for key `%s` modified, skipping autoRehydrate.', key)
+      newState[key] = reducedState[key]
+      return
+    }
+
+    // otherwise take the inboundState
+    if (isStatePlainEnough(inboundState[key]) && isStatePlainEnough(state[key])) {
+      if (controllableProps.indexOf(key) > -1) {
+        newState[key] = state[key]
+      } else newState[key] = merge(state[key], inboundState[key])
+    } else newState[key] = inboundState[key] // hard set
+
+      if (log) console.log('redux-persist/autoRehydrate: key `%s`, rehydrated to ', key, newState[key])
+    })
+  return newState
+}
+
+function isStatePlainEnough (a) {
+  // isPlainObject + duck type not immutable
+  if (!a) return false
+  if (typeof a !== 'object') return false
+  if (typeof a.asMutable === 'function') return false
+  if (!isPlainObject(a)) return false
+  return true
+}


### PR DESCRIPTION
fixes #67 

Remember, if supplying `filters` and `filterFields` properties, you must listen to the respective `onChange` events and call `setState` with the new values in order to reflect the user's update filter actions back to the UI.
