### PR TITLE
V3 fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "react-image": "^2.2.0",
     "react-intl": "^3.2.3",
     "react-mapbox-gl": "^4.6.0",
-    "react-swipeable-views": "^0.13.3",
+    "react-swipeable-views": "0.13.3",
     "react-virtualized": "^9.21.1",
     "react-virtualized-auto-sizer": "^1.0.2",
     "react-window": "^1.8.5",

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,5 +1,5 @@
 // @flow
-import mime from 'mime/lite'
+import mime from 'mime'
 import type { Observation } from 'mapeo-schema'
 
 import { getFields as getFieldsFromTags } from '../lib/data_analysis'


### PR DESCRIPTION
react-swipeable-views has published many bad 'patches' lately, so I recommend we pin that particular module as it seems to be maintained rather haphazardly.

Here's the fix, which hasn't been merged: https://github.com/oliviertassinari/react-swipeable-views/pull/580

For some reason, `mime/lite` was not resolving and that package has [since been deprecated](https://github.com/broofa/node-mime/blob/master/README.md), but importing simply `mime` seems to work still.