### PR TITLE
fix: Select should properly respect value/label objects for options

### DIFF
--- a/src/ObservationDialog/ObservationDialog.stories.js
+++ b/src/ObservationDialog/ObservationDialog.stories.js
@@ -32,7 +32,7 @@ const getPreset = observation => {
       {
         id: 'multi-field',
         key: ['multi'],
-        options: ['one', 'two', 'three'],
+        options: [{label: 'one', value: 1}, {label: 'two', value: 2}, {label: 'three', value: 3}],
         type: 'select_multiple'
       },
       {
@@ -66,7 +66,7 @@ export const openClose = () => {
   const [open, setOpen] = React.useState(false)
   const obs =
     exampleObservations[Math.floor(Math.random() * exampleObservations.length)]
-  obs.tags.multi = ['one', 'two', 'three']
+  obs.tags.multi = [1, 2, 3]
   return (
     <>
       <Button onClick={() => setOpen(true)}>Open Dialog</Button>

--- a/src/ObservationDialog/Select.js
+++ b/src/ObservationDialog/Select.js
@@ -65,12 +65,12 @@ type Props = {
 function Encoder (options) {
   return {
     toValue: (v) => {
-      var opts = options.find((ops) => ops.label === v)
+      var opts = options.find((ops) => ops.label === v.toString())
       return opts && opts.value || v
     },
     toLabel: (v) => {
       var opts = options.find((ops) => ops.value === v)
-      return opts && opts.label || v
+      return opts && opts.label || v.toString()
     }
   }
 }

--- a/src/ObservationDialog/Select.js
+++ b/src/ObservationDialog/Select.js
@@ -97,7 +97,7 @@ export const SelectOne = ({
       id={id}
       value={encoder.toLabel(value)}
       onChange={(e, v) => onChange(encoder.toValue(v))}
-      options={options.map(op => (typeof op === 'object' ? op.label : op))}
+      options={options.map(op => (op && typeof op.label === 'string' ? op.label : op))}
       renderInput={params =>
         renderInput({ ...params, classes, label, placeholder })
       }

--- a/src/ObservationDialog/Select.js
+++ b/src/ObservationDialog/Select.js
@@ -1,10 +1,15 @@
 // @flow
-import React from 'react'
+import * as React from 'react'
 import TextField from './TextField'
 import Autocomplete from '@material-ui/lab/Autocomplete'
 import { makeStyles } from '@material-ui/core/styles'
 
-import type { SelectableFieldValue, SelectOptions } from '../types'
+import { primitiveToString } from '../utils/strings'
+import type {
+  SelectableFieldValue,
+  LabeledSelectOption,
+  SelectOptions
+} from '../types'
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -54,25 +59,53 @@ function renderInput(inputProps) {
   )
 }
 
-type Props = {
-  id: string,
+type SelectOneProps = {
+  id?: string,
+  label: string | React.Element<any>,
   value: SelectableFieldValue,
   placeholder?: string,
-  onChange: (value: SelectableFieldValue) => any,
+  onChange: (value: SelectableFieldValue | void) => any,
   options: SelectOptions
 }
 
-function Encoder (options) {
+type SelectMultipleProps = {
+  ...$Exact<SelectOneProps>,
+  value: Array<SelectableFieldValue>
+}
+
+function Encoder(options: Array<LabeledSelectOption>) {
   return {
-    toValue: (v) => {
-      var opts = options.find((ops) => ops.label === v.toString())
-      return opts && opts.value || v
+    toValue: (label: string | null): SelectableFieldValue | void => {
+      if (label === null) return
+      var opts = options.find(ops => ops.label === label)
+      return opts && typeof opts.value !== 'undefined' ? opts.value : label
     },
-    toLabel: (v) => {
-      var opts = options.find((ops) => ops.value === v)
-      return opts && opts.label || v.toString()
+    toLabel: (value: SelectableFieldValue): string => {
+      var opts = options.find(ops => ops.value === value)
+      return (opts && opts.label) || primitiveToString(value)
     }
   }
+}
+
+function isSelectableFieldValue(
+  v: SelectableFieldValue | LabeledSelectOption
+): boolean %checks {
+  return (
+    typeof v === 'string' ||
+    typeof v === 'boolean' ||
+    typeof v === 'number' ||
+    v === null
+  )
+}
+
+function getLabeledSelectOptions(
+  options: SelectOptions
+): Array<LabeledSelectOption> {
+  return options.map(opt =>
+    isSelectableFieldValue(opt)
+      ? { label: primitiveToString(opt), value: opt }
+      : opt
+  )
 }
 
 /**
@@ -88,16 +121,17 @@ export const SelectOne = ({
   placeholder,
   onChange,
   ...props
-}: Props) => {
+}: SelectOneProps) => {
   const classes = useStyles()
-  const encoder = Encoder(options)
+  const labeledOptions = getLabeledSelectOptions(options)
+  const encoder = Encoder(labeledOptions)
 
   return (
     <Autocomplete
       id={id}
       value={encoder.toLabel(value)}
-      onChange={(e, v) => onChange(encoder.toValue(v))}
-      options={options.map(op => (op && typeof op.label === 'string' ? op.label : op))}
+      onChange={(e, v: string) => onChange(encoder.toValue(v))}
+      options={labeledOptions.map(opt => opt.label)}
       renderInput={params =>
         renderInput({ ...params, classes, label, placeholder })
       }
@@ -114,9 +148,10 @@ export const SelectMultiple = ({
   placeholder,
   onChange,
   ...props
-}: Props) => {
+}: SelectMultipleProps) => {
   const classes = useStyles()
-  const encoder = Encoder(options)
+  const labeledOptions = getLabeledSelectOptions(options)
+  const encoder = Encoder(labeledOptions)
   return (
     <Autocomplete
       id={id}
@@ -124,7 +159,7 @@ export const SelectMultiple = ({
       freeSolo
       value={(value || []).map(encoder.toLabel)}
       onChange={(e, v) => onChange(v.map(encoder.toValue))}
-      options={options.map(op => (op && typeof op.label === 'string' ? op.label : op))}
+      options={labeledOptions.map(opt => opt.label)}
       renderInput={params =>
         renderInput({ ...params, classes, label, placeholder })
       }

--- a/src/ObservationDialog/Select.js
+++ b/src/ObservationDialog/Select.js
@@ -124,7 +124,7 @@ export const SelectMultiple = ({
       freeSolo
       value={(value || []).map(encoder.toLabel)}
       onChange={(e, v) => onChange(v.map(encoder.toValue))}
-      options={options.map(op => (typeof op === 'object' ? op.label : op))}
+      options={options.map(op => (op && typeof op.label === 'string' ? op.label : op))}
       renderInput={params =>
         renderInput({ ...params, classes, label, placeholder })
       }

--- a/src/ObservationDialog/Select.js
+++ b/src/ObservationDialog/Select.js
@@ -62,6 +62,19 @@ type Props = {
   options: SelectOptions
 }
 
+function Encoder (options) {
+  return {
+    toValue: (v) => {
+      var opts = options.find((ops) => ops.label === v)
+      return opts && opts.value || v
+    },
+    toLabel: (v) => {
+      var opts = options.find((ops) => ops.value === v)
+      return opts && opts.label || v
+    }
+  }
+}
+
 /**
  * A multi-select field that allows the user to enter a value that is not on the
  * list. Allows the selection of non-string values from a list, but the labels
@@ -77,11 +90,13 @@ export const SelectOne = ({
   ...props
 }: Props) => {
   const classes = useStyles()
+  const encoder = Encoder(options)
+
   return (
     <Autocomplete
       id={id}
-      value={value}
-      onChange={(e, v) => onChange(v)}
+      value={encoder.toLabel(value)}
+      onChange={(e, v) => onChange(encoder.toValue(v))}
       options={options.map(op => (typeof op === 'object' ? op.label : op))}
       renderInput={params =>
         renderInput({ ...params, classes, label, placeholder })
@@ -101,13 +116,14 @@ export const SelectMultiple = ({
   ...props
 }: Props) => {
   const classes = useStyles()
+  const encoder = Encoder(options)
   return (
     <Autocomplete
       id={id}
       multiple
       freeSolo
-      value={value || []}
-      onChange={(e, v) => onChange(v)}
+      value={(value || []).map(encoder.toLabel)}
+      onChange={(e, v) => onChange(v.map(encoder.toValue))}
       options={options.map(op => (typeof op === 'object' ? op.label : op))}
       renderInput={params =>
         renderInput({ ...params, classes, label, placeholder })

--- a/src/ObservationDialog/Select.stories.js
+++ b/src/ObservationDialog/Select.stories.js
@@ -12,7 +12,7 @@ const countries = [
   { label: 'Andorra' },
   { label: 'Angola' },
   { label: 'Anguilla' },
-  { label: 'Antarctica' },
+  { label: 'Antarctica', value: 1 },
   { label: 'Antigua and Barbuda' },
   { label: 'Argentina' },
   { label: 'Armenia' },
@@ -76,6 +76,19 @@ defaultStory.story = {
 
 export const selectMultiple = () => (
   <StateContainer initialValue={['botsy']}>
+    {(value, setValue) => (
+      <SelectMultiple
+        label="Select Countries"
+        options={countries}
+        value={value}
+        onChange={setValue}
+      />
+    )}
+  </StateContainer>
+)
+
+export const selectMultipleNonStringValue= () => (
+  <StateContainer initialValue={[true, 1]}>
     {(value, setValue) => (
       <SelectMultiple
         label="Select Countries"

--- a/src/ObservationDialog/Select.stories.js
+++ b/src/ObservationDialog/Select.stories.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react'
+import { action } from '@storybook/addon-actions'
 
 import { SelectOne, SelectMultiple } from './Select'
 
@@ -36,20 +37,27 @@ const countries = [
   },
   { label: 'Bonaire, Sint Eustatius and Saba' },
   { label: 'Bosnia and Herzegovina' },
-  { label: 'Botswana' , value: 'botsy' },
+  { label: 'Botswana', value: 'botsy' },
   { label: 'Bouvet Island' },
   { label: 'Brazil' },
   { label: 'British Indian Ocean Territory' },
   { label: 'Brunei Darussalam' }
-].map(item => ({ label: item.label, value: item.value || item.label }))
+]
+  .map(item => ({
+    label: item.label,
+    value: item.value || item.label.toLowerCase().replace(' ', '_')
+  }))
+  .concat(['Other', false, 3, null])
 
 const StateContainer = ({
   initialValue,
   children
 }: {
+  initialValue: any,
   children: (any, (any) => any) => React.Node
 }) => {
   const [state, setState] = React.useState(initialValue)
+  action('onChange')(state)
   return children(state, setState)
 }
 
@@ -87,7 +95,7 @@ export const selectMultiple = () => (
   </StateContainer>
 )
 
-export const selectMultipleNonStringValue= () => (
+export const selectMultipleNonStringValue = () => (
   <StateContainer initialValue={[true, 1]}>
     {(value, setValue) => (
       <SelectMultiple

--- a/src/ObservationDialog/Select.stories.js
+++ b/src/ObservationDialog/Select.stories.js
@@ -36,7 +36,7 @@ const countries = [
   },
   { label: 'Bonaire, Sint Eustatius and Saba' },
   { label: 'Bosnia and Herzegovina' },
-  { label: 'Botswana' },
+  { label: 'Botswana' , value: 'botsy' },
   { label: 'Bouvet Island' },
   { label: 'Brazil' },
   { label: 'British Indian Ocean Territory' },
@@ -75,7 +75,7 @@ defaultStory.story = {
 }
 
 export const selectMultiple = () => (
-  <StateContainer initialValue={['Botswana']}>
+  <StateContainer initialValue={['botsy']}>
     {(value, setValue) => (
       <SelectMultiple
         label="Select Countries"

--- a/src/types.js
+++ b/src/types.js
@@ -207,9 +207,12 @@ export type NumberField = {
 
 export type SelectableFieldValue = number | string | boolean | null
 
-export type SelectOptions = Array<
-  SelectableFieldValue | {| value: SelectableFieldValue, label: string |}
->
+export type LabeledSelectOption = {|
+  value: SelectableFieldValue,
+  label: string
+|}
+
+export type SelectOptions = Array<SelectableFieldValue | LabeledSelectOption>
 
 export type SelectOneField = {
   ...BaseField,

--- a/src/utils/strings.js
+++ b/src/utils/strings.js
@@ -22,6 +22,18 @@ export function getLocalizedFieldProp(
   return label
 }
 
+export function primitiveToString(
+  value: string | boolean | number | null
+): string {
+  if (typeof value === 'string') return value
+  // TODO: Create translatable strings
+  if (typeof value === 'boolean') return value ? 'True' : 'False'
+  if (typeof value === 'number') return value.toString()
+  // TODO: what to show (translated) for "null" field (vs. undefined)
+  if (value === null) return 'No Value'
+  return ''
+}
+
 export function fieldKeyToLabel(key: Key): string | string[] {
   const fieldkey = typeof key === 'string' ? [key] : [...key]
   const labelArray = fieldkey.map(s => titleCase(s + ''))


### PR DESCRIPTION
Updated storybook tests to expect a value that is different than label so as to better represent real-world data